### PR TITLE
Should resolve tsconfig.json like Parcel does

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Simply add `parcel-resolver-ts-base-url` to your `.parcelrc`:
 }
 ```
 
-> At the moment `parcel` doesn't provide a way to specify `tsconfig.json` location I know of. `parcel-resolver-ts-base-url` will use `tsconfig.json` from the project root.
+> At the moment `parcel` doesn't provide a way to specify `tsconfig.json` location I know of. `parcel-resolver-ts-base-url` will look for `tsconfig.json` recursively from the import location to the project root (`.parcelrc` location) like Parcel itself does.
 
 Read more about `parcel` configuration in [official docs](https://parceljs.org/features/plugins/).
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-tests=("base-url" "paths" "base-url-paths" "base-url-resource" "paths-resource" "base-url-paths-resource" "paths-invalid-match" "no-tsconfig" "invalid-tsconfig")
+tests=("base-url" "paths" "base-url-paths" "base-url-resource" "paths-resource" "base-url-paths-resource" "paths-invalid-match" "no-tsconfig" "invalid-tsconfig" "js-import")
 negative_tests=("paths-invalid-match" "invalid-tsconfig")
 
 contains_element() {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,10 +4,6 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-# parcel would not allow to use multiple .tsconfig.json files in the same npm project
-# to combat this we move npm and parcel files around test directories
-# so that we do not have to duplicate files and install deps multiple times
-files_to_move=("node_modules" ".parcelrc" "package.json" "yarn.lock")
 tests=("base-url" "paths" "base-url-paths" "base-url-resource" "paths-resource" "base-url-paths-resource" "paths-invalid-match")
 negative_tests=("paths-invalid-match")
 
@@ -27,37 +23,25 @@ is_negative_test(){
     fi
 }
 
-move_files() {
-    for file in "${files_to_move[@]}";
-    do
-        mv "$1$file" "$2$file"
-    done
-}
-
 cleanup(){
-    move_files "" "../"
-
     rm -rf .parcel-cache index*
 
     printf "${RED}TEST \"$1\" FAILED!!!${NC}\n"
 
-    cd ..
     exit 1
 }
 
 run_test() {
-    cd $1
     printf "\n======================\n"
     printf "Running test \"$1\"...\n"
     if is_negative_test $1;
     then
-        yarn parcel build src/main.ts &> /dev/null && cleanup $1
+        yarn parcel build $1/src/main.ts &> /dev/null && cleanup $1
     else
-        yarn parcel build src/main.ts &> /dev/null || cleanup $1
+        yarn parcel build $1/src/main.ts &> /dev/null || cleanup $1
     fi
     rm -rf .parcel-cache index*
     printf "${GREEN}TEST \"$1\" SUCCESSFUL${NC}\n"
-    cd ..
 }
 
 cd tests
@@ -67,7 +51,6 @@ yarn install &> /dev/null || (printf "${RED}FAILED TO INSTALL DEPS${NC}\n" && ex
 cp ../index.js node_modules/parcel-resolver-ts-base-url/index.js
 printf "Deps installed\n"
 
-move_files "" "${tests[0]}/"
 run_test ${tests[0]}
 
 for index in "${!tests[@]}";
@@ -77,9 +60,7 @@ do
         continue
     fi
 
-    move_files "${tests[$index-1]}/" "${tests[$index]}/"
     run_test ${tests[$index]}
 done
 
-move_files "${tests[${#tests[@]} - 1]}/" ""
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,8 +4,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-tests=("base-url" "paths" "base-url-paths" "base-url-resource" "paths-resource" "base-url-paths-resource" "paths-invalid-match")
-negative_tests=("paths-invalid-match")
+tests=("base-url" "paths" "base-url-paths" "base-url-resource" "paths-resource" "base-url-paths-resource" "paths-invalid-match" "no-tsconfig" "invalid-tsconfig")
+negative_tests=("paths-invalid-match" "invalid-tsconfig")
 
 contains_element() {
   local e match="$1"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
 const POSSIBLE_EXTENSIONS = ["js", "jsx", "ts", "tsx", "cjs", "mjs"];
 
-export { POSSIBLE_EXTENSIONS };
+const POSSIBLE_EXTENSION_REGEX = /[.](([cm]js)|([jt]sx?))$/;
+
+export { POSSIBLE_EXTENSIONS, POSSIBLE_EXTENSION_REGEX };

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,15 @@ import { parsePaths } from "./steps/parse-paths";
 import { resolveBase } from "./steps/resolve-base";
 import { resolvePath } from "./steps/resolve-path";
 
+import { POSSIBLE_EXTENSION_REGEX } from "./constants";
+
 export default new Resolver({
     async resolve({ specifier, dependency, options }) {
-        const isTypescriptImport = /\.tsx?$/g.test(
+        const isJavascriptImport = POSSIBLE_EXTENSION_REGEX.test(
             dependency.resolveFrom || ""
         );
 
-        if (!isTypescriptImport) {
+        if (!isJavascriptImport) {
             return null;
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,21 @@ export default new Resolver({
                     invalidateOnFileChange: [resolvedFromBase],
                 };
             }
-        } catch (err) {}
+        } catch (err) {
+            return {
+                diagnostics: [
+                    {
+                        message:
+                            err instanceof Error
+                                ? err.message
+                                : "Unknown error",
+                        hints: [
+                            "Check if a tsconfig.json file exists and has valid configuration in it",
+                        ],
+                    },
+                ],
+            };
+        }
 
         return null;
     },

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,8 @@ export default new Resolver({
 
         try {
             const tsConfig = await getTsConfig(
-                options.projectRoot,
-                options.inputFS
+                options.inputFS,
+                options.projectRoot
             );
 
             const rawBaseUrl = tsConfig?.compilerOptions?.baseUrl || ".";
@@ -39,10 +39,10 @@ export default new Resolver({
 
             if (matchedPath !== null) {
                 const resolved = await resolvePath(
+                    options.inputFS,
                     specifier,
                     matchedPath,
-                    baseUrl,
-                    options.inputFS
+                    baseUrl
                 );
 
                 if (!resolved) {
@@ -56,9 +56,9 @@ export default new Resolver({
             }
 
             const resolvedFromBase = await resolveBase(
+                options.inputFS,
                 specifier,
-                baseUrl,
-                options.inputFS
+                baseUrl
             );
 
             if (resolvedFromBase !== null) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,19 +20,22 @@ export default new Resolver({
         }
 
         try {
-            const tsConfig = await getTsConfig(
+            const { tsConfig, path: sourcePath } = await getTsConfig(
                 options.inputFS,
+                dependency.resolveFrom
+                    ? path.dirname(dependency.resolveFrom)
+                    : options.projectRoot,
                 options.projectRoot
             );
 
-            const rawBaseUrl = tsConfig?.compilerOptions?.baseUrl || ".";
-            const rawPaths = tsConfig?.compilerOptions?.paths;
+            const rawBaseUrl = tsConfig.compilerOptions?.baseUrl;
+            const rawPaths = tsConfig.compilerOptions?.paths;
 
             if (!rawBaseUrl && !rawPaths) {
                 return null;
             }
 
-            const baseUrl = path.resolve(options.projectRoot, rawBaseUrl);
+            const baseUrl = path.resolve(sourcePath, rawBaseUrl || ".");
             const paths = parsePaths(rawPaths);
 
             const matchedPath = matchPath(specifier, paths);

--- a/src/steps/resolve-base.js
+++ b/src/steps/resolve-base.js
@@ -3,15 +3,15 @@ import path from "path";
 import { matchFile } from "../utils/match-file";
 
 /**
+ * @param {import('@parcel/fs').FileSystem} fs
  * @param {string} specifier
  * @param {string} baseUrl
- * @param {import('@parcel/fs').FileSystem} fs
  * @returns {Promise<string | null>}
  */
-const resolveBase = async (specifier, baseUrl, fs) => {
+const resolveBase = async (fs, specifier, baseUrl) => {
     const filePath = path.resolve(baseUrl, specifier);
 
-    return await matchFile(filePath, fs);
+    return await matchFile(fs, filePath);
 };
 
 export { resolveBase };

--- a/src/steps/resolve-path.js
+++ b/src/steps/resolve-path.js
@@ -3,13 +3,13 @@ import path from "path";
 import { matchFile } from "../utils/match-file";
 
 /**
+ * @param {import('@parcel/fs').FileSystem} fs
  * @param {string} specifier
  * @param {import('./parse-paths').Path} matchedPath
  * @param {string} baseUrl
- * @param {import('@parcel/fs').FileSystem} fs
  * @returns {Promise<string | null>}
  */
-const resolvePath = async (specifier, matchedPath, baseUrl, fs) => {
+const resolvePath = async (fs, specifier, matchedPath, baseUrl) => {
     const strippedMatch = matchedPath.match.replace("*", "");
 
     const wildcard = specifier.replace(strippedMatch, "");
@@ -22,7 +22,7 @@ const resolvePath = async (specifier, matchedPath, baseUrl, fs) => {
     for (const resolve of resolves) {
         const filePath = path.resolve(baseUrl, resolve.replace("*", wildcard));
 
-        const matchedFile = await matchFile(filePath, fs);
+        const matchedFile = await matchFile(fs, filePath);
 
         if (matchedFile) {
             return matchedFile;

--- a/src/utils/get-package.js
+++ b/src/utils/get-package.js
@@ -4,11 +4,11 @@ import { createMemo } from "./memo";
 
 /**
  * @param {import('./memo').Memo<Record<string, unknown>>} memo
- * @param {string} folder
  * @param {import('@parcel/fs').FileSystem} fs
+ * @param {string} folder
  * @returns {Promise<Record<string, unknown> | null>}
  */
-const getPackage = async (memo, folder, fs) => {
+const getPackage = async (memo, fs, folder) => {
     if (memo[folder]) {
         return memo[folder];
     }

--- a/src/utils/get-ts-config.js
+++ b/src/utils/get-ts-config.js
@@ -16,18 +16,34 @@ const getTsConfig = async (memo, fs, sourcePath, projectRoot) => {
         }
 
         const tsConfigPath = path.join(sourcePath, "tsconfig.json");
-        if (await fs.exists(tsConfigPath)) {
-            const tsConfigContent = await fs.readFile(tsConfigPath, "utf-8");
 
-            return {
-                tsConfig: (memo[sourcePath] = JSON.parse(tsConfigContent)),
-                path: sourcePath,
-            };
+        try {
+            if (await fs.exists(tsConfigPath)) {
+                const tsConfigContent = await fs.readFile(
+                    tsConfigPath,
+                    "utf-8"
+                );
+
+                return {
+                    tsConfig: (memo[sourcePath] = JSON.parse(tsConfigContent)),
+                    path: sourcePath,
+                };
+            }
+        } catch (err) {
+            throw new Error(
+                `Unexpected exception when reading ${path.relative(
+                    projectRoot,
+                    tsConfigPath
+                )}: ${err instanceof Error ? err.message : err}`
+            );
         }
 
         if (sourcePath === projectRoot) {
             throw new Error(
-                "[parcel-resolver-ts-paths] tsconfig.json not found"
+                `tsconfig.json not found in ${path.relative(
+                    projectRoot,
+                    sourcePath
+                )}`
             );
         }
 

--- a/src/utils/get-ts-config.js
+++ b/src/utils/get-ts-config.js
@@ -5,18 +5,34 @@ import { createMemo } from "./memo";
 /**
  * @param {import('./memo').Memo<Record<string, unknown>>} memo
  * @param {import('@parcel/fs').FileSystem} fs
+ * @param {string} sourcePath
  * @param {string} projectRoot
- * @returns {Promise<Record<string, any>>}
+ * @returns {Promise<{ tsConfig: Record<string, any>, path: string }>}
  */
-const getTsConfig = async (memo, fs, projectRoot) => {
-    if (memo[projectRoot]) {
-        return memo[projectRoot];
+const getTsConfig = async (memo, fs, sourcePath, projectRoot) => {
+    while (true) {
+        if (memo[sourcePath]) {
+            return { tsConfig: memo[sourcePath], path: sourcePath };
+        }
+
+        const tsConfigPath = path.join(sourcePath, "tsconfig.json");
+        if (await fs.exists(tsConfigPath)) {
+            const tsConfigContent = await fs.readFile(tsConfigPath, "utf-8");
+
+            return {
+                tsConfig: (memo[sourcePath] = JSON.parse(tsConfigContent)),
+                path: sourcePath,
+            };
+        }
+
+        if (sourcePath === projectRoot) {
+            throw new Error(
+                "[parcel-resolver-ts-paths] tsconfig.json not found"
+            );
+        }
+
+        sourcePath = path.join(sourcePath, "..");
     }
-
-    const tsConfigPath = path.join(projectRoot, "tsconfig.json");
-    const tsConfigContent = await fs.readFile(tsConfigPath, "utf-8");
-
-    return (memo[projectRoot] = JSON.parse(tsConfigContent));
 };
 
 const memoizedGetTsConfig = createMemo(getTsConfig);

--- a/src/utils/get-ts-config.js
+++ b/src/utils/get-ts-config.js
@@ -4,11 +4,11 @@ import { createMemo } from "./memo";
 
 /**
  * @param {import('./memo').Memo<Record<string, unknown>>} memo
- * @param {string} projectRoot
  * @param {import('@parcel/fs').FileSystem} fs
+ * @param {string} projectRoot
  * @returns {Promise<Record<string, any>>}
  */
-const getTsConfig = async (memo, projectRoot, fs) => {
+const getTsConfig = async (memo, fs, projectRoot) => {
     if (memo[projectRoot]) {
         return memo[projectRoot];
     }

--- a/src/utils/match-file.js
+++ b/src/utils/match-file.js
@@ -5,11 +5,12 @@ import { POSSIBLE_EXTENSIONS } from "../constants";
 import { getPackage } from "./get-package";
 
 /**
- * @param {string} matchedPath
  * @param {import('@parcel/fs').FileSystem} fs
+ * @param {string} matchedPath
  * @param {string[]} extensions
+ * @returns {Promise<string | null>}
  */
-const matchFile = async (matchedPath, fs, extensions = POSSIBLE_EXTENSIONS) => {
+const matchFile = async (fs, matchedPath, extensions = POSSIBLE_EXTENSIONS) => {
     const exists = await fs.exists(matchedPath);
 
     const stat = exists && (await fs.stat(matchedPath));
@@ -20,7 +21,7 @@ const matchFile = async (matchedPath, fs, extensions = POSSIBLE_EXTENSIONS) => {
             return matchedPath;
         }
 
-        const pkg = await getPackage(matchedPath, fs);
+        const pkg = await getPackage(fs, matchedPath);
 
         const main = pkg && (pkg.main || pkg.module);
         if (typeof main === "string") {

--- a/tests/invalid-tsconfig/src/main.ts
+++ b/tests/invalid-tsconfig/src/main.ts
@@ -1,0 +1,3 @@
+import { test } from "utils/test";
+
+test();

--- a/tests/invalid-tsconfig/src/utils/test.ts
+++ b/tests/invalid-tsconfig/src/utils/test.ts
@@ -1,0 +1,3 @@
+export const test = () => {
+    console.log("test");
+};

--- a/tests/invalid-tsconfig/tsconfig.json
+++ b/tests/invalid-tsconfig/tsconfig.json
@@ -1,0 +1,5 @@
+error{
+    "compilerOptions": {
+        "baseUrl": "src"
+    }
+}

--- a/tests/js-import/src/main.ts
+++ b/tests/js-import/src/main.ts
@@ -1,0 +1,3 @@
+import { test } from "./test";
+
+test();

--- a/tests/js-import/src/test.js
+++ b/tests/js-import/src/test.js
@@ -1,0 +1,1 @@
+export * from "utils/test";

--- a/tests/js-import/src/utils/test.js
+++ b/tests/js-import/src/utils/test.js
@@ -1,0 +1,3 @@
+export const test = () => {
+    console.log("test");
+};

--- a/tests/js-import/tsconfig.json
+++ b/tests/js-import/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    }
+}

--- a/tests/no-tsconfig/src/main.ts
+++ b/tests/no-tsconfig/src/main.ts
@@ -1,0 +1,3 @@
+import { test } from "./utils/test";
+
+test();

--- a/tests/no-tsconfig/src/utils/test.ts
+++ b/tests/no-tsconfig/src/utils/test.ts
@@ -1,0 +1,3 @@
+export const test = () => {
+    console.log("test");
+};


### PR DESCRIPTION
Solves #3

Should also help with #2. JavaScript projects may now employ this plugin by using `tsconfig.json`. Resolver will work for any of `cjs,mjs,js,jsx,ts,tsx` extensions. So any proper aliased import from not only Typescript but also Javascript file will resolve.